### PR TITLE
Add page version restore functionality

### DIFF
--- a/src/main/java/net/unit8/rotom/RotomApplicationFactory.java
+++ b/src/main/java/net/unit8/rotom/RotomApplicationFactory.java
@@ -42,6 +42,7 @@ public class RotomApplicationFactory implements ApplicationFactory<HttpRequest, 
             r.get("/edit/*path").to(WikiController.class, "edit");
             r.post("/edit/*dummy").to(WikiController.class, "update");
             r.post("/delete/*path").to(WikiController.class, "delete");
+            r.post("/restore/*path").to(WikiController.class, "restore");
             r.get("/history/*path").to(WikiController.class, "history");
             r.post("/compare/*path").to(WikiController.class, "compare");
             r.get("/compare/*path/:hash1..:hash2").to(WikiController.class, "doCompare");

--- a/src/main/java/net/unit8/rotom/WikiController.java
+++ b/src/main/java/net/unit8/rotom/WikiController.java
@@ -263,6 +263,10 @@ public class WikiController {
     public HttpResponse restore(Parameters params, UserPermissionPrincipal principal) {
         String path = sanitizePath(params.get("path"));
         String sha1 = params.get("sha1");
+        if (sha1 == null || !sha1.matches("[a-f0-9]{40}")) {
+            return UrlRewriter.redirect(WikiController.class,
+                    "history?path=" + path, SEE_OTHER);
+        }
 
         Page oldPage = wiki.getPage(path, ObjectId.fromString(sha1));
         if (oldPage == null) {

--- a/src/main/java/net/unit8/rotom/WikiController.java
+++ b/src/main/java/net/unit8/rotom/WikiController.java
@@ -258,4 +258,34 @@ public class WikiController {
         response.setContentType("text/html; charset=utf-8");
         return response;
     }
+
+    @RolesAllowed("page:edit")
+    public HttpResponse restore(Parameters params, UserPermissionPrincipal principal) {
+        String path = sanitizePath(params.get("path"));
+        String sha1 = params.get("sha1");
+
+        Page oldPage = wiki.getPage(path, ObjectId.fromString(sha1));
+        if (oldPage == null) {
+            return UrlRewriter.redirect(WikiController.class,
+                    "history?path=" + path, SEE_OTHER);
+        }
+
+        PersonIdent committer;
+        if (principal != null) {
+            committer = new PersonIdent(principal.getName(), Objects.toString(principal.getProfiles().get("email")));
+        } else {
+            committer = new PersonIdent("anonymous", "anonymous@example.com");
+        }
+
+        Page currentPage = wiki.getPage(path);
+        wiki.updatePage(currentPage, null, null,
+                oldPage.getTextData().getBytes(StandardCharsets.UTF_8),
+                new Commit(committer.getName(), committer.getEmailAddress(),
+                        "Restored to version " + sha1.substring(0, 8)));
+
+        Page updated = wiki.getPage(path);
+        indexManager.save(updated);
+        return UrlRewriter.redirect(WikiController.class,
+                "showPageOrFile?path=" + updated.getUrlPath(), SEE_OTHER);
+    }
 }

--- a/src/main/resources/templates/history.ftl
+++ b/src/main/resources/templates/history.ftl
@@ -43,13 +43,15 @@
                                         ${version.shortMessage}
                                         [<a href="${urlFor('showPageOrFile?path=' + page.urlPath + '&sha1=' + version.id.getName())}">${version.id.getName()[0..7]}</a>]
                                     </td>
-                                    <#if hasPermission(userPrincipal, 'page:edit') && !version?is_first>
+                                    <#if hasPermission(userPrincipal, 'page:edit')>
                                     <td class="restore">
+                                        <#if !version?is_first>
                                         <form method="post" action="${urlFor('restore?path=' + page.urlPath)}"
                                               onsubmit="return confirm('Restore this page to version ${version.id.getName()[0..7]}?');">
                                             <input type="hidden" name="sha1" value="${version.id.getName()}">
                                             <button type="submit" class="minibutton">Restore</button>
                                         </form>
+                                        </#if>
                                     </td>
                                     </#if>
                                 </tr>

--- a/src/main/resources/templates/history.ftl
+++ b/src/main/resources/templates/history.ftl
@@ -43,6 +43,15 @@
                                         ${version.shortMessage}
                                         [<a href="${urlFor('showPageOrFile?path=' + page.urlPath + '&sha1=' + version.id.getName())}">${version.id.getName()[0..7]}</a>]
                                     </td>
+                                    <#if hasPermission(userPrincipal, 'page:edit') && !version?is_first>
+                                    <td class="restore">
+                                        <form method="post" action="${urlFor('restore?path=' + page.urlPath)}"
+                                              onsubmit="return confirm('Restore this page to version ${version.id.getName()[0..7]}?');">
+                                            <input type="hidden" name="sha1" value="${version.id.getName()}">
+                                            <button type="submit" class="minibutton">Restore</button>
+                                        </form>
+                                    </td>
+                                    </#if>
                                 </tr>
                             </#list>
                         </tbody>


### PR DESCRIPTION
## Summary
- Add `POST /restore/*path` endpoint that restores a page to a previous version by creating a new commit with the old content (non-destructive)
- Add "Restore" button on each version row in the history page (hidden for the latest version)
- Require `page:edit` permission; show browser confirmation dialog before restoring
- Commit message includes restored version's short SHA (e.g., "Restored to version a1b2c3d4")

Closes #17

## Test plan
- [ ] `mvn clean test` passes (13 tests)
- [ ] Create a page, edit it several times to build history
- [ ] Open `/history/PageName` — Restore buttons visible on all rows except the latest
- [ ] Click Restore on an older version — confirmation dialog appears
- [ ] Confirm — page content reverts to the selected version
- [ ] History shows new "Restored to version xxxxxxxx" commit
- [ ] User without `page:edit` permission does not see Restore buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)