### PR TITLE
Fix NPE in restore() when current page has been deleted

### DIFF
--- a/src/main/java/net/unit8/rotom/WikiController.java
+++ b/src/main/java/net/unit8/rotom/WikiController.java
@@ -294,6 +294,10 @@ public class WikiController {
                         "Restored to version " + sha1.substring(0, 8)));
 
         Page updated = wiki.getPage(path);
+        if (updated == null) {
+            return UrlRewriter.redirect(WikiController.class,
+                    "history?path=" + path, SEE_OTHER);
+        }
         indexManager.save(updated);
         return UrlRewriter.redirect(WikiController.class,
                 "showPageOrFile?path=" + updated.getUrlPath(), SEE_OTHER);

--- a/src/main/java/net/unit8/rotom/WikiController.java
+++ b/src/main/java/net/unit8/rotom/WikiController.java
@@ -284,6 +284,10 @@ public class WikiController {
         PersonIdent committer = toPersonIdent(principal);
 
         Page currentPage = wiki.getPage(path);
+        if (currentPage == null) {
+            return UrlRewriter.redirect(WikiController.class,
+                    "history?path=" + path, SEE_OTHER);
+        }
         wiki.updatePage(currentPage, null, null,
                 oldPage.getTextData().getBytes(StandardCharsets.UTF_8),
                 new Commit(committer.getName(), committer.getEmailAddress(),

--- a/src/test/java/net/unit8/rotom/WikiControllerIntegrationTest.java
+++ b/src/test/java/net/unit8/rotom/WikiControllerIntegrationTest.java
@@ -339,6 +339,24 @@ class WikiControllerIntegrationTest {
     }
 
     @Test
+    void restoreWhenCurrentPageDeletedRedirectsToHistory() throws Exception {
+        // Create a page, capture its SHA, then delete it so currentPage is null at restore time
+        wiki.writePage("deleted-page", "markdown", "# original".getBytes(StandardCharsets.UTF_8),
+                null, new Commit("test", "test@example.com", "initial"));
+        var versions = wiki.getVersions(enkan.collection.OptionMap.of(
+                "path", wiki.getPage("deleted-page").getPath()));
+        String sha = versions.get(0).getId().getName();
+        wiki.deletePage(wiki.getPage("deleted-page"),
+                new Commit("test", "test@example.com", "delete"));
+
+        Parameters params = Parameters.of("path", "deleted-page", "sha1", sha);
+        HttpResponse response = controller.restore(params, null);
+        assertEquals(303, statusOf(response));
+        assertTrue(locationOf(response).contains("history"),
+                "restore() on a deleted page should redirect to history, not throw NPE");
+    }
+
+    @Test
     void restoreValidShaRestoresPageContent() throws Exception {
         wiki.writePage("restore-target", "markdown", "# v1 content".getBytes(StandardCharsets.UTF_8),
                 null, new Commit("test", "test@example.com", "v1"));


### PR DESCRIPTION
## Summary

- `WikiController.restore()` called `wiki.updatePage(currentPage, ...)` without checking if `currentPage` is null
- If the page is deleted between history rendering and the restore request, this causes a NullPointerException (500 error)
- Add a null-check that redirects to history — consistent with the existing null-check for the historical SHA

## Test plan

- [x] `restoreWhenCurrentPageDeletedRedirectsToHistory` — new regression test
- [x] All 155 tests pass (`mvn test`)

## Related

Identified by code review after merging PR #23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)