### PR TITLE
Make Lucene index path configurable via INDEX_PATH env var

### DIFF
--- a/src/main/java/net/unit8/rotom/RotomSystemFactory.java
+++ b/src/main/java/net/unit8/rotom/RotomSystemFactory.java
@@ -48,7 +48,7 @@ public class RotomSystemFactory implements EnkanSystemFactory {
                         .set(Wiki::setRepository, getRepository())
                         .build(),
                 "index", builder(new IndexManager())
-                        .set(IndexManager::setIndexPath, Paths.get("index"))
+                        .set(IndexManager::setIndexPath, Paths.get(Env.getString("INDEX_PATH", "index")))
                         .build(),
                 "config", builder(new RotomConfiguration())
                         .set(RotomConfiguration::setBasePath, basePath)


### PR DESCRIPTION
## Summary

- `INDEX_PATH` 環境変数でLuceneインデックスのパスを指定可能に
- 未設定時は従来通り `"index"`（カレントディレクトリ直下）にフォールバック
- `REPO_PATH` / `BASE_PATH` と同じ設定パターンに統一

## Usage

```bash
INDEX_PATH=/var/lib/rotom/index java -jar rotom.jar
```

## Test plan

- [x] 全155テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)